### PR TITLE
Integrate snap versioning via github workflow

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -17,4 +17,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
+          version-schema: '^debian/(\d+\.\d+\.\d+)'
           

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,7 @@
 name: gutenprint-printer-app
 base: core22
+version: '5.3.4-2'
+grade: stable
 summary: Gutenprint Printer Application
 description: |
   The Gutenprint Printer Application is a PAPPL (Printer Application
@@ -438,13 +440,17 @@ parts:
     after: [cups, ghostscript, libcupsfilters]
 
   gutenprint:
-    source: https://github.com/echiu64/gutenprint.git
+    # github source
+    # source: https://github.com/echiu64/gutenprint.git
+    source: https://salsa.debian.org/printing-team/gutenprint.git
     source-type: git
-    source-tag: 'gutenprint-5_3_3'
+    source-tag: 'debian/5.3.4.20220624T01008808d602-1'
+    # github source tag
+    # source-tag: 'gutenprint-5_3_3'
     source-depth: 1
 # ext:updatesnap
 #   version-format:
-#     format: 'gutenprint-%M_%m_%R'
+#     format: 'debian/%V'
 #     lower-than: '6'
 #     no-9x-revisions: true
     plugin: autotools
@@ -470,67 +476,6 @@ parts:
       - --disable-testpattern
       - --enable-nls
       - --without-doc
-    override-pull: |
-      set -eux
-      # Do the actual pull task
-      craftctl default
-      # Settings:
-      # Force channel: auto/devel/edge/stable
-      CHANNEL=stable
-      # Force package release number (integer) or "auto"
-      PACKAGERELEASE=auto
-      # Time stamp of Snap build in Snap Store
-      snapbuilddatehuman=`curl -s -H 'Snap-Device-Series: 16' https://api.snapcraft.io/v2/snaps/info/gutenprint-printer-app | jq -r '."channel-map" | .[] | select(.channel.name == "edge") | select(.channel.architecture == "amd64") | ."created-at"'`
-      snapbuilddate=`date +%s --date=$snapbuilddatehuman`
-      if [ -z "$snapbuilddate" ]; then
-          snapbuilddate=0
-      fi
-      # Time stamp of the last GIT commit of the snapping repository
-      pushd $CRAFT_PROJECT_DIR
-      gitcommitdate=`git log -1 --date=unix | grep Date: | perl -p -e 's/Date:\s*//'`
-      popd
-      if [ -z "$gitcommitdate" ]; then
-          gitcommitdate=0
-      fi
-      # Previous stable and development version
-      prevstable="$(curl -s -H 'Snap-Device-Series: 16' https://api.snapcraft.io/v2/snaps/info/gutenprint-printer-app | jq -r '."channel-map" | .[] | select(.channel.name == "stable") | select(.channel.architecture == "'$CRAFT_TARGET_ARCH'") | .version')"
-      if [ -z "$prevstable" ]; then
-          prevstable=0
-      fi
-      prevdevel="$(curl -s -H 'Snap-Device-Series: 16' https://api.snapcraft.io/v2/snaps/info/gutenprint-printer-app | jq -r '."channel-map" | .[] | select(.channel.name == "edge") | select(.channel.architecture == "'$CRAFT_TARGET_ARCH'") | .version')"
-      if [ -z "$prevdevel" ]; then
-          prevdevel=0
-      fi
-      # Previous version in general
-      dpkg --compare-versions "$prevdevel" lt "$prevstable" && prevversion=$prevstable || prevversion=$prevdevel
-      # Current upstream version of gutenprint
-      upstreamversion="$(git describe --tags --always | sed -E 's/^gutenprint-([0-9]+_[0-9]+_[0-9]+).*$/\1/; s/_/\./g')"
-      # Determine package release number
-      if test "x$PACKAGERELEASE" = "xauto"; then
-          packagerelease=`echo "$prevversion" | perl -p -e 's/^('"$upstreamversion"'\-(\d+)|.*)$/\2/'`
-          if [ -z "$packagerelease" ]; then
-              packagerelease=1
-          else
-              if test "$gitcommitdate" -gt "$snapbuilddate"; then
-                  packagerelease=$(( $packagerelease + 1 ))
-              fi
-          fi
-      else
-          packagerelease=$PACKAGERELEASE
-      fi
-      # Compose version string
-      version="$upstreamversion-$packagerelease"
-      # Select channel
-      if test "x$CHANNEL" = "xedge" -o "x$CHANNEL" = "xdevel"; then
-          grade=devel
-      elif test "x$CHANNEL" = "xstable"; then
-          grade=stable
-      else
-          [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
-      fi
-      # Set version and grade
-      craftctl set version="$version"
-      craftctl set grade="$grade"
     build-packages:
       - byacc
       - libreadline-dev
@@ -540,7 +485,6 @@ parts:
       - gettext
       - chrpath
       - libtool-bin
-      - jq
       - curl
     organize:
       snap/gutenprint-printer-app/current/usr/share: usr/share


### PR DESCRIPTION
- implemented the latest workflow from ubuntu/desktop-snaps, which incorporates an automated snap versioning system into the snap.
- removed jq from the build packages, as it is no longer required.
-  changed the gutenprint source to pull from Debian instead of GitHub.