### PR TITLE
Fixes Registry Actions & Unable to encrypt connection: Unable to create server credentials Issue

### DIFF
--- a/.github/workflows/registry-actions.yml
+++ b/.github/workflows/registry-actions.yml
@@ -73,25 +73,28 @@ jobs:
         uses: docker/login-action@v3.2.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Docker Image (Edge & Latest Channel)
         if: github.event.inputs.workflow_choice == 'edge' || github.event.inputs.workflow_choice == 'both' || github.event_name == 'push' || github.event_name == 'workflow_run'
         env:
           USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          ORG: ${{ github.repository_owner }}
         run: |
           IMAGE="$(yq '.name' rockcraft.yaml)"
           VERSION="$(yq '.version' rockcraft.yaml)"
           ROCK="$(ls *.rock | tail -n 1)"
-          sudo rockcraft.skopeo --insecure-policy copy oci-archive:"${ROCK}" docker-daemon:"${USERNAME}/${IMAGE}:${VERSION}-edge"
+          ORG_NAME=$(echo "${ORG}" | tr '[:upper:]' '[:lower:]')
+          sudo rockcraft.skopeo --insecure-policy copy oci-archive:"${ROCK}" docker-daemon:"${ORG_NAME}/${IMAGE}:${VERSION}-edge"
           # Push to Docker Hub
+          # docker tag ${ORG_NAME}/${IMAGE}:${VERSION}-edge ${USERNAME}:${VERSION}-edge
           # docker push ${USERNAME}/${IMAGE}:${VERSION}-edge
           # docker tag ${USERNAME}/${IMAGE}:${VERSION}-edge ${USERNAME}/${IMAGE}:latest
           # docker push ${USERNAME}/${IMAGE}:latest
           # Push to GitHub Packages
-          GITHUB_IMAGE="ghcr.io/${{ github.repository_owner }}/${IMAGE}"
-          docker tag ${USERNAME}/${IMAGE}:${VERSION}-edge ${GITHUB_IMAGE}:${VERSION}-edge
+          GITHUB_IMAGE="ghcr.io/${ORG_NAME}/${IMAGE}"
+          docker tag ${ORG_NAME}/${IMAGE}:${VERSION}-edge ${GITHUB_IMAGE}:${VERSION}-edge
           docker push ${GITHUB_IMAGE}:${VERSION}-edge
           docker tag ${GITHUB_IMAGE}:${VERSION}-edge ${GITHUB_IMAGE}:latest
           docker push ${GITHUB_IMAGE}:latest
@@ -100,14 +103,17 @@ jobs:
         if: github.event.inputs.workflow_choice == 'stable' || github.event.inputs.workflow_choice == 'both'
         env:
           USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          ORG: ${{ github.repository_owner }}
         run: |
             IMAGE="$(yq '.name' rockcraft.yaml)"
             VERSION="$(yq '.version' rockcraft.yaml)"
             ROCK="$(ls *.rock | tail -n 1)"
-            sudo rockcraft.skopeo --insecure-policy copy oci-archive:"${ROCK}" docker-daemon:"${USERNAME}/${IMAGE}:${VERSION}-stable"
+            ORG_NAME=$(echo "${ORG}" | tr '[:upper:]' '[:lower:]')
+            sudo rockcraft.skopeo --insecure-policy copy oci-archive:"${ROCK}" docker-daemon:"${ORG_NAME}/${IMAGE}:${VERSION}-stable"
             # Push to Docker Hub
+            # docker tag ${ORG_NAME}/${IMAGE}:${VERSION}-stable ${USERNAME}:${VERSION}-stable
             # docker push ${USERNAME}/${IMAGE}:${VERSION}-stable
             # Push to GitHub Packages
-            GITHUB_IMAGE="ghcr.io/${{ github.repository_owner }}/${IMAGE}"
-            docker tag ${USERNAME}/${IMAGE}:${VERSION}-stable ${GITHUB_IMAGE}:${VERSION}-stable
+            GITHUB_IMAGE="ghcr.io/${ORG_NAME}/${IMAGE}"
+            docker tag ${ORG_NAME}/${IMAGE}:${VERSION}-stable ${GITHUB_IMAGE}:${VERSION}-stable
             docker push ${GITHUB_IMAGE}:${VERSION}-stable

--- a/README.md
+++ b/README.md
@@ -223,19 +223,38 @@ configuring SNMP network printer discovery.
 
 #### Step-by-Step Guide
 
-The first step is to pull the gutenprint-printer-app Docker image from Docker Hub.
+You can pull the `gutenprint-printer-app` Docker image from either the GitHub Container Registry or Docker Hub.
+
+**From GitHub Container Registry** <br>
+To pull the image from the GitHub Container Registry, run the following command:
+```sh
+  sudo docker pull ghcr.io/openprinting/gutenprint-printer-app:latest
+```
+
+To run the container after pulling the image from the GitHub Container Registry, use:
+```sh
+  sudo docker run -d \
+      --name gutenprint-printer-app \
+      --network host \
+      -e PORT=<port> \
+      ghcr.io/openprinting/gutenprint-printer-app:latest
+```
+
+**From Docker Hub** <br>
+Alternatively, you can pull the image from Docker Hub, by running:
 ```sh
   sudo docker pull openprinting/gutenprint-printer-app
 ```
 
-Run the following Docker command to run the gutenprint-printer-app image:
+To run the container after pulling the image from Docker Hub, use:
 ```sh
-  sudo docker run --rm -d \
+  sudo docker run -d \
       --name gutenprint-printer-app \
       --network host \
       -e PORT=<port> \
       openprinting/gutenprint-printer-app:latest
 ```
+
 - `PORT` is an optional environment variable used to start the printer-app on a specified port. If not provided, it will start on the default port 8000 or, if port 8000 is busy, on 8001 and so on.
 - **The container must be started in `--network host` mode** to allow the Printer-Application instance inside the container to access and discover printers available in the local network where the host system is in.
 - Alternatively using the internal network of the Docker instance (`-p <port>:8000` instead of `--network host -e PORT=<port>`) only gives access to local printers running on the host system itself.
@@ -279,7 +298,7 @@ Once the rock is built, you need to compile docker image from it.
 **Run the gutenprint-printer-app Docker Container**
 
 ```sh
-  sudo docker run --rm -d \
+  sudo docker run -d \
       --name gutenprint-printer-app \
       --network host \
       -e PORT=<port> \

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -13,8 +13,8 @@ fi
 CUPS_SERVERROOT="/etc/cups/ssl"
 if [ ! -d "$CUPS_SERVERROOT" ]; then
     mkdir -p "$CUPS_SERVERROOT"
-    chmod 755 "$CUPS_SERVERROOT"
 fi
+chmod 755 "$CUPS_SERVERROOT"
 
 # Ensure /var/lib/gutenprint-printer-app directory exists
 STATE_DIR="/var/lib/gutenprint-printer-app"

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -9,4 +9,27 @@ if [ -n "${PORT:-}" ]; then
     fi
 fi
 
+# Ensure the /etc/cups/ssl directory exists with proper permissions
+CUPS_SERVERROOT="/etc/cups/ssl"
+if [ ! -d "$CUPS_SERVERROOT" ]; then
+    mkdir -p "$CUPS_SERVERROOT"
+    chmod 755 "$CUPS_SERVERROOT"
+fi
+
+# Ensure /var/lib/gutenprint-printer-app directory exists
+STATE_DIR="/var/lib/gutenprint-printer-app"
+
+if [ ! -d "$STATE_DIR" ]; then
+    mkdir -p "$STATE_DIR"
+fi
+chmod 755 "$STATE_DIR"
+
+# Ensure gutenprint-printer-app.state file exists
+STATE_FILE="$STATE_DIR/gutenprint-printer-app.state"
+if [ ! -f "$STATE_FILE" ]; then
+    touch "$STATE_FILE"
+fi
+chmod 755 "$STATE_FILE"
+
+# Start the gutenprint-printer-app server
 gutenprint-printer-app -o log-file=/gutenprint-printer-app.log ${PORT:+-o server-port=$PORT} server


### PR DESCRIPTION
- Fixes Registry Actions
- Update README with OCI image instructions for GitHub Container Registry
- Enhance start-server script to create missing directories and files (`CUPS_SERVERROOT`, `STATE_DIR`, `STATE_FILE`) with appropriate permissions