### PR TITLE
Update driver_display_regex to match drivers shipped in the snap

### DIFF
--- a/gutenprint-printer-app.c
+++ b/gutenprint-printer-app.c
@@ -127,13 +127,13 @@ main(int  argc,				// I - Number of command-line arguments
     // the expert PPDs. NOTE: In this case we should build Gutenprint
     // with only the expert PPDs as this regex does not exclude the
     // simplified PPDs.
-    driver_display_regex = " +- +CUPS\\+Gutenprint[ v0-9.]*()$";
+    driver_display_regex = " +- +CUPS\\+Gutenprint +[^ ]+()$";
   else
     // With PAPPL in stock configuration (from system, distro package,
     // ...) use simplified PPDs, as PAPPL cannot cope with the huge
     // amount of options of the expert PPDs (only 32 vendor-specific
     // options allowed
-    driver_display_regex = " +- +CUPS\\+Gutenprint.*Simplified()";
+    driver_display_regex = " +- +CUPS\\+Gutenprint +[^ ]+ +Simplified()$";
 
   // Configuration record of the Printer Application
   pr_printer_app_config_t printer_app_config =


### PR DESCRIPTION
Fixes: https://github.com/OpenPrinting/gutenprint-printer-app/issues/9

In this MR the `driver_display_regex` values are changed to match the names of PPDs included in the snap. Eg.

```
$ /snap/gutenprint-printer-app/current/usr/share/ppd/gutenprint.5.3 list|grep QW410
"gutenprint.5.3://dnp-qw410/expert" en "Dai Nippon Printing" "Dai Nippon Printing QW410 - CUPS+Gutenprint v5.3.4-2022-06-24T01-00-8808d602" "MANUFACTURER:Dai Nippon Printing ;MODEL:DP-QW410;"
"gutenprint.5.3://dnp-qw410/simple" en "Dai Nippon Printing" "Dai Nippon Printing QW410 - CUPS+Gutenprint v5.3.4-2022-06-24T01-00-8808d602 Simplified" "MANUFACTURER:Dai Nippon Printing ;MODEL:DP-QW410;"
```

In the examples above (and in the current snap), the version string is `v5.3.4-2022-06-24T01-00-8808d602` and not just `v.5.3.4` expected by the current regex. As a result, the driver list on the web UI is empty and it is not possible to add a printer.

After the changes the list is populated with the available drivers and printer can be added.